### PR TITLE
feat: move loading to popup menu

### DIFF
--- a/lib/context-pad/RefactoringsContextPadProvider.js
+++ b/lib/context-pad/RefactoringsContextPadProvider.js
@@ -1,25 +1,15 @@
-import { render } from '@bpmn-io/properties-panel/preact';
-import { useEffect, useRef, useState } from '@bpmn-io/properties-panel/preact/hooks';
-
-import { html } from '@bpmn-io/diagram-js-ui';
-import { query as domQuery } from 'min-dom';
-
-import { TooltipEntry } from '@bpmn-io/properties-panel';
 
 export default class RefactoringsContextPadProvider {
-  constructor(contextPad, popupMenu, refactoringsPopupMenuProvider, eventBus) {
-    contextPad.registerProvider(10, this);
+  constructor(contextPad, popupMenu, refactoringsPopupMenuProvider) {
+    contextPad.registerProvider(100, this);
 
+    this._contextPad = contextPad;
     this._popupMenu = popupMenu;
     this._refactoringsPopupMenuProvider = refactoringsPopupMenuProvider;
-
-    eventBus.on('contextPad.open', 100, this._renderEntry.bind(this));
-    eventBus.on('contextPad.close', 100, this._removeEntry.bind(this));
   }
 
   _getPopupMenuPosition(target) {
     const Y_OFFSET = 10;
-
 
     const targetBB = target.getBoundingClientRect();
     return {
@@ -29,14 +19,27 @@ export default class RefactoringsContextPadProvider {
   }
 
   getContextPadEntries(element) {
+    const self = this;
     return function(entries) {
+
+      // Pre-fetch results:
+      self._refactoringsPopupMenuProvider.fetchRefactoringActions(element);
+
       return {
         ...entries,
         alert: {
-          action: () => {},
+          action: () => {
+            const pad = self._contextPad.getPad(element);
+            self._openPopupMenu(pad, element);
+          },
           group: 'suggest-refactoring',
           className: 'suggest-refactoring',
-          html: '<div id="refactoring-action-placeholder" class="entry"></div>'
+          html: `<div class="entry" title="Suggest refactorings">
+            <svg width="30" height="30" viewBox="6 6 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M16.7219 13.2691L16.7212 13.2684C15.6661 12.2119 14.7435 10.4757 14.0638 9.00772C14.0445 9.00316 14.0206 9 13.9941 9C13.9675 9 13.9436 9.00316 13.9243 9.00773C13.2447 10.4757 12.322 12.2122 11.2662 13.2687C10.2106 14.325 8.47501 15.2485 7.00803 15.9287C7.00329 15.9483 7 15.9728 7 16C7 16.0271 7.00325 16.0515 7.00794 16.071C8.47467 16.751 10.2101 17.6743 11.2659 18.7311C12.322 19.7875 13.2448 21.5244 13.9245 22.9923C13.9437 22.9969 13.9675 23 13.994 23C14.0205 23 14.0444 22.9968 14.0636 22.9923C14.7433 21.5244 15.666 19.7877 16.7215 18.7315M16.7215 18.7315C17.773 17.6791 19.4531 16.7468 20.8721 16.0577C20.8756 16.0415 20.878 16.0217 20.878 15.9998C20.878 15.9779 20.8756 15.9582 20.8721 15.942C19.4537 15.2529 17.7734 14.3207 16.7219 13.2691" fill="currentcolor"/>
+              <path fill-rule="evenodd" clip-rule="evenodd" d="M22.4808 9.52468L22.4805 9.52442C22.1037 9.14711 21.7742 8.52704 21.5315 8.00276C21.5246 8.00113 21.5161 8 21.5066 8C21.4971 8 21.4885 8.00113 21.4817 8.00276C21.2389 8.52705 20.9094 9.14721 20.5323 9.52455C20.1553 9.9018 19.5355 10.2316 19.0116 10.4745C19.0099 10.4815 19.0087 10.4903 19.0087 10.5C19.0087 10.5097 19.0099 10.5184 19.0115 10.5254C19.5354 10.7682 20.1552 11.098 20.5322 11.4754C20.9094 11.8527 21.239 12.473 21.4817 12.9972C21.4886 12.9989 21.4971 13 21.5066 13C21.516 13 21.5246 12.9989 21.5314 12.9972C21.7742 12.473 22.1037 11.8528 22.4806 11.4755M22.4806 11.4755C22.8562 11.0997 23.4562 10.7667 23.963 10.5206C23.9643 10.5148 23.9651 10.5078 23.9651 10.4999C23.9651 10.4921 23.9643 10.4851 23.963 10.4793C23.4565 10.2332 22.8563 9.90026 22.4808 9.52468" fill="currentcolor"/>
+            </svg>
+          </div>`
         }
       };
     };
@@ -44,135 +47,17 @@ export default class RefactoringsContextPadProvider {
 
   _openPopupMenu(pad, element) {
     this._popupMenu.open(element, 'refactoring-actions',
-      this._getPopupMenuPosition(pad),
+      this._getPopupMenuPosition(pad.html),
       {
         title: 'Apply refactorings',
         width: 350
       }
     );
   }
-
-  // Hook into context pad rending events to add Preact Micro-Frontend
-  // In the future, we want the context pad to support Preact components natively
-  _renderEntry({ current }) {
-    const placeHolder = domQuery('#refactoring-action-placeholder', current.pad.html);
-
-    if (placeHolder) {
-      render(html`<${RefactoringActionItem}
-        element=${current.target}
-        setClass=${(name) => placeHolder.classList.toggle(name) }
-        refactoringsPopupMenuProvider=${this._refactoringsPopupMenuProvider}
-        openPopupMenu=${() => this._openPopupMenu(current.pad.html, current.target)}
-      />`, placeHolder
-      );
-    }
-  }
-
-  _removeEntry({ current }) {
-    const placeHolder = domQuery('#refactoring-action-placeholder', current.pad.html);
-
-    if (placeHolder) {
-      render(null, placeHolder);
-    }
-  }
 }
 
 RefactoringsContextPadProvider.$inject = [
   'contextPad',
   'popupMenu',
-  'refactoringsPopupMenuProvider',
-  'eventBus'
+  'refactoringsPopupMenuProvider'
 ];
-
-function RefactoringActionItem(props) {
-  const {
-    element,
-    refactoringsPopupMenuProvider,
-    openPopupMenu,
-    setClass
-  } = props;
-
-  const [ loadingState, setLoadingState ] = useState('INITIAL');
-  const previousLoadingState = usePrevious(loadingState);
-
-  useEffect(() => {
-    const load = async () => {
-      const suggestedRefactoring = await refactoringsPopupMenuProvider.fetchRefactoringActions(element);
-
-      if (suggestedRefactoring[0]) {
-        setLoadingState('LOADED');
-      } else {
-        setLoadingState('EMPTY');
-        setClass('empty');
-      }
-    };
-
-    load();
-  }, []);
-
-  useEffect(() => {
-    if (previousLoadingState === 'LOADING' && loadingState === 'LOADED') {
-      openPopupMenu();
-    }
-  }, [ loadingState, previousLoadingState ]);
-
-  return html`
-    <${TooltipEntry} value=${getTooltipTitle(loadingState)} position="bottom: 100%;" direction="top">
-      ${loadingState === 'INITIAL' ? html`<div onClick=${() => setLoadingState('LOADING')} role="button">
-        <${RefactoringIcon}/>
-        </div>` : null}
-      ${loadingState === 'LOADING' ? html`<${LoadingIcon} />` : null}
-      ${loadingState === 'EMPTY' ? html`<${RefactoringIcon} domclass="no-refactorings-available"/>` : null}
-      ${loadingState === 'LOADED' ? html`<div onClick=${openPopupMenu} role="button">
-          <${RefactoringIcon}/>
-        </div>` : null}
-      </${TooltipEntry}>
-  `;
-}
-
-function RefactoringIcon(props) {
-  const {
-    domclass = ''
-  } = props;
-
-  return html`<div class="refactoring-icon ${domclass}" >
-  <svg width="30" height="30" viewBox="6 6 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M16.7219 13.2691L16.7212 13.2684C15.6661 12.2119 14.7435 10.4757 14.0638 9.00772C14.0445 9.00316 14.0206 9 13.9941 9C13.9675 9 13.9436 9.00316 13.9243 9.00773C13.2447 10.4757 12.322 12.2122 11.2662 13.2687C10.2106 14.325 8.47501 15.2485 7.00803 15.9287C7.00329 15.9483 7 15.9728 7 16C7 16.0271 7.00325 16.0515 7.00794 16.071C8.47467 16.751 10.2101 17.6743 11.2659 18.7311C12.322 19.7875 13.2448 21.5244 13.9245 22.9923C13.9437 22.9969 13.9675 23 13.994 23C14.0205 23 14.0444 22.9968 14.0636 22.9923C14.7433 21.5244 15.666 19.7877 16.7215 18.7315M16.7215 18.7315C17.773 17.6791 19.4531 16.7468 20.8721 16.0577C20.8756 16.0415 20.878 16.0217 20.878 15.9998C20.878 15.9779 20.8756 15.9582 20.8721 15.942C19.4537 15.2529 17.7734 14.3207 16.7219 13.2691" fill="currentcolor"/>
-    <path fill-rule="evenodd" clip-rule="evenodd" d="M22.4808 9.52468L22.4805 9.52442C22.1037 9.14711 21.7742 8.52704 21.5315 8.00276C21.5246 8.00113 21.5161 8 21.5066 8C21.4971 8 21.4885 8.00113 21.4817 8.00276C21.2389 8.52705 20.9094 9.14721 20.5323 9.52455C20.1553 9.9018 19.5355 10.2316 19.0116 10.4745C19.0099 10.4815 19.0087 10.4903 19.0087 10.5C19.0087 10.5097 19.0099 10.5184 19.0115 10.5254C19.5354 10.7682 20.1552 11.098 20.5322 11.4754C20.9094 11.8527 21.239 12.473 21.4817 12.9972C21.4886 12.9989 21.4971 13 21.5066 13C21.516 13 21.5246 12.9989 21.5314 12.9972C21.7742 12.473 22.1037 11.8528 22.4806 11.4755M22.4806 11.4755C22.8562 11.0997 23.4562 10.7667 23.963 10.5206C23.9643 10.5148 23.9651 10.5078 23.9651 10.4999C23.9651 10.4921 23.9643 10.4851 23.963 10.4793C23.4565 10.2332 22.8563 9.90026 22.4808 9.52468" fill="currentcolor"/>
-  </svg>
-</div>`;
-}
-
-function LoadingIcon() {
-  return html`
-  <div class="cds--layout">
-<div class="cds--loading cds--loading--small">
-  <svg viewBox="0 0 100 100" class="cds--loading__svg">
-  <circle cx="50%" cy="50%" class="cds--loading__stroke" r="40"></circle>
-</svg>
-</div>
-</div>`;
-}
-
-
-function usePrevious(value) {
-  const currentRef = useRef(value);
-  const previousRef = useRef();
-  if (currentRef.current !== value) {
-    previousRef.current = currentRef.current;
-    currentRef.current = value;
-  }
-  return previousRef.current;
-}
-
-function getTooltipTitle(state) {
-  if (state === 'LOADING') {
-    return 'Loading refactorings';
-  }
-
-  if (state === 'EMPTY') {
-    return 'No refactorings available';
-  }
-
-  return 'Suggest refactoring';
-}

--- a/lib/popup-menu/RefactoringsPopupMenuProvider.js
+++ b/lib/popup-menu/RefactoringsPopupMenuProvider.js
@@ -1,24 +1,36 @@
+import { html } from '@bpmn-io/diagram-js-ui';
+import { isArray } from 'min-dash';
 
 /**
    * An entry provider for the popup menu that shows available refactorings.
    */
 export default class RefactoringsPopupMenuProvider {
-  constructor(popupMenu, translate, refactorings) {
+  constructor(popupMenu, translate, refactorings, eventBus) {
     this._popupMenu = popupMenu;
     this._translate = translate;
     this._refactorings = refactorings;
 
-    this._fetchedRefactorings = new Map();
+    this._fetchedRefactorings = null;
+
+    eventBus.on('popupMenu.closed', () => {
+      this._fetchedRefactorings = null;
+    });
 
     this.register();
   }
 
   async fetchRefactoringActions(element) {
-    const refactorings = await this._refactorings.getRefactorings([ element ]);
+    this._fetchedRefactorings = this._refactorings.getRefactorings([ element ]);
+    this._fetchedRefactorings = await this._fetchedRefactorings;
 
-    this._fetchedRefactorings.set(element, refactorings);
+    // We need to refresh the popup menu in a fresh event cycle
+    // Otherwise, if the promise resolves immediately, the click event
+    // in the context pad will be captured as outside the menu and force
+    // the popup menu to close immediately
+    window.setTimeout(() => {
+      this._popupMenu.refresh();
+    });
 
-    return refactorings;
   }
 
   register() {
@@ -26,9 +38,18 @@ export default class RefactoringsPopupMenuProvider {
   }
 
   getPopupMenuEntries(element) {
-    const refactorings = this._fetchedRefactorings.get(element) || [];
+    const refactorings = this._fetchedRefactorings;
 
-    return refactorings.reduce((entries, refactoring) => {
+    if (!refactorings) {
+      this.fetchRefactoringActions(element);
+    }
+
+    // We are still loading
+    if (!isArray(refactorings)) {
+      return {};
+    }
+
+    const entries = (refactorings || []).reduce((entries, refactoring) => {
       entries[ refactoring.id ] = {
         label: refactoring.label || refactoring.name,
         action: () => {
@@ -37,12 +58,43 @@ export default class RefactoringsPopupMenuProvider {
       };
       return entries;
     }, {});
+
+    return entries;
+  }
+
+  getEmptyPlaceholder() {
+    if (!isArray(this._fetchedRefactorings)) {
+      return html`<span><${LoadingIcon}/></span>`;
+    } else {
+      return 'There are no refactorings available for this element. Please try again with a different element.';
+    }
+
   }
 }
 
 RefactoringsPopupMenuProvider.$inject = [
   'popupMenu',
   'translate',
-  'refactorings'
+  'refactorings',
+  'eventBus'
 ];
 
+
+function LoadingIcon() {
+  return html`
+      <div class="cds--layout">
+        <div class="cds--inline-loading" aria-live="assertive">
+          <div class="cds--inline-loading__animation">
+            <div aria-atomic="true" aria-live="assertive" class="cds--loading cds--loading--small">
+              <svg class="cds--loading__svg" viewBox="0 0 100 100">
+                <title>Loading</title>
+                <circle class="cds--loading__background" cx="50%" cy="50%" r="42"></circle>
+                <circle class="cds--loading__stroke" cx="50%" cy="50%" r="42"></circle>
+              </svg>
+            </div>
+          </div>
+          <div class="cds--inline-loading__text">Loading refactorings...</div>
+        </div>
+      </div>
+`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@carbon/styles": "^1.53.1",
         "bpmn-js": "^17.0.2",
         "bpmn-js-element-templates": "^1.14.1",
+        "diagram-js": "^14.3.0",
         "min-dash": "^4.2.1",
         "min-dom": "^5.0.0"
       },
@@ -5435,13 +5436,13 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-14.1.0.tgz",
-      "integrity": "sha512-oXgcOBe7egDyguB00BKD7Yq8A2qCpR9KZWWJcl8rmykwX+oXmCkDeDpS+isC6DINpSjal1NSwyeSOMObbI1piA==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-14.3.0.tgz",
+      "integrity": "sha512-ARhvGJH3VGrOOIcI1wC67hB8rWwKDL4jkvmTnS0fLbF0NbTmyy8jUg8ODxV0cCBk1IgOHplyN+ObIHkylCk3bQ==",
       "dependencies": {
-        "@bpmn-io/diagram-js-ui": "^0.2.2",
+        "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
-        "didi": "^10.0.1",
+        "didi": "^10.2.2",
         "inherits-browser": "^0.1.0",
         "min-dash": "^4.1.0",
         "min-dom": "^4.1.0",
@@ -5515,9 +5516,9 @@
       }
     },
     "node_modules/didi": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.1.tgz",
-      "integrity": "sha512-NaPoyMxu+78E2O6xE9JQkeTpmVhMcu8xneIKtSfqBuGUBU7LmNUaYtJXJQ2JWRx6iYY69oj4nerXVRWGXAw/IQ==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
+      "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w==",
       "engines": {
         "node": ">= 16"
       }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@carbon/styles": "^1.53.1",
     "bpmn-js": "^17.0.2",
     "bpmn-js-element-templates": "^1.14.1",
+    "diagram-js": "^14.3.0",
     "min-dash": "^4.2.1",
     "min-dom": "^5.0.0"
   },

--- a/test/spec/context-pad/MockPopupMenuProvider.js
+++ b/test/spec/context-pad/MockPopupMenuProvider.js
@@ -3,19 +3,8 @@
    * An entry provider for the popup menu that shows available refactorings.
    */
 export class MockPopupMenuProvider {
-  constructor() {
-    this.resolve = () => {};
-    this.promise = null;
-    this.result = null;
-  }
+  fetchRefactoringActions() { }
 
-  fetchRefactoringActions() {
-    return this.result;
-  }
-
-  setResult(result) {
-    this.result = result;
-  }
 }
 
 MockPopupMenuProvider.$inject = [];

--- a/test/spec/context-pad/RefactoringsContextPadProvider.spec.js
+++ b/test/spec/context-pad/RefactoringsContextPadProvider.spec.js
@@ -40,7 +40,7 @@ describe('Context Pad', function() {
     contextPad.open(task);
 
     // then
-    expect(domQuery('#refactoring-action-placeholder')).to.exist;
+    expect(domQuery('.entry.suggest-refactoring')).to.exist;
   }));
 
 
@@ -53,55 +53,34 @@ describe('Context Pad', function() {
     contextPad.open(task);
 
     // then
-    expect(domQuery('#refactoring-action-placeholder .refactoring-icon')).to.exist;
+    expect(domQuery('.entry.suggest-refactoring')).to.exist;
   }));
 
 
-  it('should show loading spinner on click', inject(async function(elementRegistry, contextPad, refactoringsPopupMenuProvider) {
+  it('should pre-fetch results in popup menu provider', inject(function(elementRegistry, contextPad, refactoringsPopupMenuProvider) {
 
     // given
     const task = elementRegistry.get('Task_1');
-
-    refactoringsPopupMenuProvider.setResult(new Promise(() => {}));
-    contextPad.open(task);
-
-    const icon = domQuery('#refactoring-action-placeholder .refactoring-icon');
-
-    // when
-    await act(() => icon.click());
-
-    // then
-    expect(domQuery('.cds--loading')).to.exist;
-  }));
-
-
-  it('should show disabled state when no refactorings are available', inject(async function(elementRegistry, contextPad, refactoringsPopupMenuProvider) {
-
-    // given
-    const task = elementRegistry.get('Task_1');
-
-    refactoringsPopupMenuProvider.setResult([]);
+    refactoringsPopupMenuProvider.fetchRefactoringActions = sinon.spy();
 
     // when
     contextPad.open(task);
 
     // then
-    waitFor(() => {
-      expect(domQuery('.no-refactorings-available')).to.exist;
-    });
+    expect(refactoringsPopupMenuProvider.fetchRefactoringActions).to.have.been.calledWith(task);
+
   }));
 
 
-  it('should open popup menu on click', inject(async function(elementRegistry, contextPad, refactoringsPopupMenuProvider, popupMenu) {
+  it('should open popup menu on click', inject(async function(elementRegistry, contextPad, popupMenu) {
 
     // given
     const task = elementRegistry.get('Task_1');
     popupMenu.open = sinon.spy();
 
-    refactoringsPopupMenuProvider.setResult([ 'some-refactoring' ]);
     contextPad.open(task);
 
-    const icon = domQuery('#refactoring-action-placeholder .refactoring-icon');
+    const icon = domQuery('.entry.suggest-refactoring');
 
     // when
     await act(() => icon.click());
@@ -114,5 +93,3 @@ describe('Context Pad', function() {
   }));
 
 });
-
-

--- a/test/spec/popup-menu/RefactoringsPopupMenuProvider.spec.js
+++ b/test/spec/popup-menu/RefactoringsPopupMenuProvider.spec.js
@@ -4,6 +4,7 @@ import {
 } from 'test/TestHelper';
 
 import {
+  query as domQuery,
   queryAll as domQueryAll,
 } from 'min-dom';
 
@@ -13,6 +14,7 @@ import RefactoringsModule from '../../../lib/refactorings';
 import RefactoringsPopupMenuModule from '../../../lib/popup-menu/';
 
 import diagramXML from '../../fixtures/bpmn/simple.bpmn';
+import { waitFor } from '@testing-library/preact';
 
 describe('Popup Menu', function() {
 
@@ -25,7 +27,7 @@ describe('Popup Menu', function() {
   }));
 
 
-  it('should fetch entries', inject(function(elementRegistry, refactoringsPopupMenuProvider, refactorings) {
+  it('should fetch refactorings', inject(function(elementRegistry, refactoringsPopupMenuProvider, refactorings) {
 
     // given
     const task = elementRegistry.get('Task_1');
@@ -39,21 +41,7 @@ describe('Popup Menu', function() {
   }));
 
 
-  it('should fetch entries', inject(async function(elementRegistry, refactoringsPopupMenuProvider, refactorings) {
-
-    // given
-    const task = elementRegistry.get('Task_1');
-    refactorings.getRefactorings = sinon.spy();
-
-    // when
-    await refactoringsPopupMenuProvider.fetchRefactoringActions(task);
-
-    // then
-    expect(refactorings.getRefactorings).to.have.been.calledWith([ task ]);
-  }));
-
-
-  it('should add entries after fetching', inject(async function(elementRegistry, refactoringsPopupMenuProvider, refactorings, popupMenu) {
+  it('should show entries after fetching', inject(async function(elementRegistry, refactoringsPopupMenuProvider, refactorings, popupMenu) {
 
     // given
     const task = elementRegistry.get('Task_1');
@@ -73,6 +61,97 @@ describe('Popup Menu', function() {
       'foo',
       'bar'
     ]);
+  }));
+
+
+  it('should show loading indicator', inject(async function(elementRegistry, refactorings, popupMenu) {
+
+    // given
+    const task = elementRegistry.get('Task_1');
+    refactorings.getRefactorings = () => new Promise(() => {});
+
+    // when
+    popupMenu.open(task, 'refactoring-actions', {
+      position: { x: 0, y: 0 }
+    });
+
+    // then
+    expect(domQuery('.djs-popup-no-results')).to.exist;
+    expect(domQuery('.djs-popup-no-results .cds--inline-loading')).to.exist;
+  }));
+
+
+  it('should show empty state', inject(async function(elementRegistry, refactorings, popupMenu) {
+
+    // given
+    const task = elementRegistry.get('Task_1');
+    refactorings.getRefactorings = () => [];
+
+    // when
+    popupMenu.open(task, 'refactoring-actions', {
+      position: { x: 0, y: 0 }
+    });
+
+    // then
+    expect(domQuery('.djs-popup-no-results')).to.exist;
+    expect(domQuery('.djs-popup-no-results .cds--inline-loading')).not.to.exist;
+  }));
+
+
+  it('should show entries when loading finises', inject(async function(elementRegistry, refactorings, popupMenu) {
+
+    // given
+    const task = elementRegistry.get('Task_1');
+    let resolve;
+    refactorings.getRefactorings = () => new Promise((r) => {resolve = r;});
+    popupMenu.open(task, 'refactoring-actions', {
+      position: { x: 0, y: 0 }
+    });
+
+    // assume
+    expect(domQuery('.djs-popup-no-results')).to.exist;
+    expect(domQuery('.djs-popup-no-results .cds--inline-loading')).to.exist;
+
+    // when
+    resolve([ { id: 'foo', label: 'foo' }, { id: 'bar', label: 'bar' } ]);
+
+    // then
+    waitFor(() => {
+      const entries = [ ...domQueryAll('.djs-popup.refactoring-actions .entry') ];
+
+      expect(entries).to.have.length(2);
+      expect(entries.map(entry => entry.getAttribute('data-id'))).to.eql([
+        'foo',
+        'bar'
+      ]);
+    });
+
+  }));
+
+
+  it('should show empty state when loading finises', inject(async function(elementRegistry, refactorings, popupMenu) {
+
+    // given
+    const task = elementRegistry.get('Task_1');
+    let resolve;
+    refactorings.getRefactorings = () => new Promise((r) => {resolve = r;});
+    popupMenu.open(task, 'refactoring-actions', {
+      position: { x: 0, y: 0 }
+    });
+
+    // assume
+    expect(domQuery('.djs-popup-no-results')).to.exist;
+    expect(domQuery('.djs-popup-no-results .cds--inline-loading')).to.exist;
+
+    // when
+    resolve([ ]);
+
+    // then
+    waitFor(() => {
+      expect(domQuery('.djs-popup-no-results')).to.exist;
+      expect(domQuery('.djs-popup-no-results .cds--inline-loading')).not.to.exist;
+    });
+
   }));
 
 });


### PR DESCRIPTION
This PR implements an alternate user-flow. The Loading is now done within the popup menu rather than the Context Pad. The Icon in the Context Pad will always be enabled.

Fetching is still initiated when the Context Pad is opened.

![Recording 2024-03-22 at 14 34 39 (1)](https://github.com/bpmn-io/refactorings/assets/21984219/7ee2693b-c577-4ba0-9d94-c23ae9f8ff74)

<!--

Thanks for creating this pull request!

Please make sure to link the issue you are closing as "Closes #issueNr". 
This helps us to understand the context of this PR.

-->
