### PR TITLE
Simplify deps

### DIFF
--- a/lib/popup-menu/RefactoringsPopupMenuProvider.js
+++ b/lib/popup-menu/RefactoringsPopupMenuProvider.js
@@ -1,4 +1,4 @@
-import { html } from '@bpmn-io/diagram-js-ui';
+import { html } from 'diagram-js/lib/ui';
 
 import { isArray } from 'min-dash';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "@carbon/styles": "^1.53.1",
         "bpmn-js": "^17.9.1",
-        "bpmn-js-element-templates": "^1.16.0",
         "diagram-js": "^14.8.0",
         "min-dash": "^4.2.1",
         "min-dom": "^5.0.0"
@@ -30,6 +29,7 @@
         "@testing-library/preact": "^3.2.3",
         "babel-loader": "^9.1.3",
         "bpmn-js-create-append-anything": "^0.5.1",
+        "bpmn-js-element-templates": "^2.3.0",
         "bpmn-js-properties-panel": "^5.14.0",
         "camunda-bpmn-js-behaviors": "^1.3.0",
         "cross-env": "^7.0.3",
@@ -68,6 +68,10 @@
         "style-loader": "^3.3.1",
         "webpack": "^5.88.2",
         "zeebe-bpmn-moddle": "^1.0.0"
+      },
+      "peerDependencies": {
+        "bpmn-js": "*",
+        "diagram-js": "*"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1795,6 +1799,7 @@
       "version": "0.1.0-alpha.2",
       "resolved": "https://registry.npmjs.org/@bpmn-io/cm-theme/-/cm-theme-0.1.0-alpha.2.tgz",
       "integrity": "sha512-ZILgiYzxk3KMvxplUXmdRFQo45/JehDPg5k9tWfehmzUOSE13ssyLPil8uCloMQnb3yyzyOWTjb/wzKXTHlFQw==",
+      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.3.1",
         "@codemirror/view": "^6.5.1",
@@ -1838,6 +1843,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/element-templates-validator/-/element-templates-validator-2.1.0.tgz",
       "integrity": "sha512-e8oYLUaZbL1ZuJjwXFyhhStbg0YgMNosIlzhKWdY7ysPhCFVMJlJ6yNYdaxyqfpPATTKb05uXMAsIgcqTQpoLg==",
+      "dev": true,
       "dependencies": {
         "@camunda/element-templates-json-schema": "^0.18.0",
         "@camunda/zeebe-element-templates-json-schema": "^0.20.0",
@@ -1849,6 +1855,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-0.8.0.tgz",
       "integrity": "sha512-yAS7ZYX+D56K+luC36u96eRMLb4VHcPUwTUqMZ/Z/Je2gou2DJLRbuBTHAB4jjKt4wFCHSG4B8Y+TrBciEYf4w==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.0.0"
       }
@@ -1857,6 +1864,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-editor/-/feel-editor-1.3.0.tgz",
       "integrity": "sha512-FuNEICeLuRHFWM7OQ0iBMXhd/iuzitbdSQlOfr0DqswVDsVUq24vV/ZTM1UnjdPp4J2gwhMuYi6a2LaiVNzRKQ==",
+      "dev": true,
       "dependencies": {
         "@bpmn-io/feel-lint": "^1.2.0",
         "@codemirror/autocomplete": "^6.12.0",
@@ -1877,6 +1885,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
       "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -1885,6 +1894,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
       "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
+      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -1895,6 +1905,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.2.0.tgz",
       "integrity": "sha512-nsvAYxiSbWyjpd3gNnJd+60aTWrZvngYnZfe+GpmkM/pQoOgtF17GhD/p4fgaeAd/uUP3q9sO6EWRX+OU/p9dw==",
+      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.8.0",
         "lezer-feel": "^1.2.3"
@@ -1907,6 +1918,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@bpmn-io/moddle-utils/-/moddle-utils-0.2.1.tgz",
       "integrity": "sha512-iv9zwk7PEGupSq9bkVZNFL0ZmoJLHExlUcjsiYx200Nh3a5mH9BHXF+PLaSaiE4882KVEirklpWf3oQLAmShSA==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.1.1"
       }
@@ -1915,6 +1927,7 @@
       "version": "3.18.2",
       "resolved": "https://registry.npmjs.org/@bpmn-io/properties-panel/-/properties-panel-3.18.2.tgz",
       "integrity": "sha512-IQ6NUZ4McSmr6KLyptnhnKxBind5Oz+FSZ5u8MJX/s/10RRj+RIVYCBS2UnfCKHZCE9YMWTdCHdA7XQ4lIjuzw==",
+      "dev": true,
       "dependencies": {
         "@bpmn-io/feel-editor": "^1.3.0",
         "@codemirror/view": "^6.14.0",
@@ -1932,6 +1945,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
       "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -1940,6 +1954,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
       "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
+      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -1949,7 +1964,8 @@
     "node_modules/@camunda/element-templates-json-schema": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/@camunda/element-templates-json-schema/-/element-templates-json-schema-0.18.0.tgz",
-      "integrity": "sha512-k2k+1Z7UiW1TSA1oAvDQamgFZljH3hkFjU9VSpjVXnPgcjVxJMLX0mrHjLVtXhEx2tw576FzYGqlfudw6OOMKg=="
+      "integrity": "sha512-k2k+1Z7UiW1TSA1oAvDQamgFZljH3hkFjU9VSpjVXnPgcjVxJMLX0mrHjLVtXhEx2tw576FzYGqlfudw6OOMKg==",
+      "dev": true
     },
     "node_modules/@camunda/improved-canvas": {
       "version": "1.7.1",
@@ -1967,7 +1983,8 @@
     "node_modules/@camunda/zeebe-element-templates-json-schema": {
       "version": "0.20.0",
       "resolved": "https://registry.npmjs.org/@camunda/zeebe-element-templates-json-schema/-/zeebe-element-templates-json-schema-0.20.0.tgz",
-      "integrity": "sha512-7YRN32Nq73H8S1rCOy2/6cfx+fKiTnhveJYfP6aRaIi83ZSlhVomRJ5+pnPmlDJqdFeNcIx1qqQwVFAdgNPFhg=="
+      "integrity": "sha512-7YRN32Nq73H8S1rCOy2/6cfx+fKiTnhveJYfP6aRaIi83ZSlhVomRJ5+pnPmlDJqdFeNcIx1qqQwVFAdgNPFhg==",
+      "dev": true
     },
     "node_modules/@carbon/colors": {
       "version": "11.21.0",
@@ -2068,6 +2085,7 @@
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.15.0.tgz",
       "integrity": "sha512-G2Zm0mXznxz97JhaaOdoEG2cVupn4JjPaS4AcNvZzhOsnnG9YVN68VzfoUw6dYTsIxT6a/cmoFEN47KAWhXaOg==",
+      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -2085,6 +2103,7 @@
       "version": "6.3.3",
       "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.3.3.tgz",
       "integrity": "sha512-dO4hcF0fGT9tu1Pj1D2PvGvxjeGkbC6RGcZw6Qs74TH+Ed1gw98jmUgd2axWvIZEqTeTuFrg1lEB1KV6cK9h1A==",
+      "dev": true,
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.4.0",
@@ -2096,6 +2115,7 @@
       "version": "6.10.1",
       "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.1.tgz",
       "integrity": "sha512-5GrXzrhq6k+gL5fjkAwt90nYDmjlzTIJV8THnxNFtNKWotMIlzzN+CpqxqwXOECnUdOndmSeWntVrVcv5axWRQ==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.23.0",
@@ -2109,6 +2129,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.5.0.tgz",
       "integrity": "sha512-+5YyicIaaAZKU8K43IQi8TBy6mF6giGeWAH7N96Z5LC30Wm5JMjqxOYIE9mxwMG1NbhT2mA3l9hA4uuKUM3E5g==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.0.0",
         "@codemirror/view": "^6.0.0",
@@ -2118,12 +2139,14 @@
     "node_modules/@codemirror/state": {
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.4.1.tgz",
-      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A=="
+      "integrity": "sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==",
+      "dev": true
     },
     "node_modules/@codemirror/view": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.26.0.tgz",
       "integrity": "sha512-nSSmzONpqsNzshPOxiKhK203R6BvABepugAe34QfQDbNDslyjkqBuKgrK5ZBvqNXpfxz5iLrlGTmEfhbQyH46A==",
+      "dev": true,
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -2335,12 +2358,14 @@
     "node_modules/@lezer/common": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.1.tgz",
-      "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ=="
+      "integrity": "sha512-yemX0ZD2xS/73llMZIK6KplkjIjf2EvAHcinDi/TfJ9hS25G0388+ClHt6/3but0oOxinTcQHJLDXh6w1crzFQ==",
+      "dev": true
     },
     "node_modules/@lezer/highlight": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.0.tgz",
       "integrity": "sha512-WrS5Mw51sGrpqjlh3d4/fOwpEV2Hd3YOkp9DBt4k8XZQcoTHZFB7sx030A6OcahF4J1nDQAa3jXlTVVYH50IFA==",
+      "dev": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -2349,6 +2374,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.0.tgz",
       "integrity": "sha512-Wst46p51km8gH0ZUmeNrtpRYmdlRHUpN1DQd3GFAyKANi8WVz8c2jHYTf1CVScFaCjQw1iO3ZZdqGDxQPRErTg==",
+      "dev": true,
       "dependencies": {
         "@lezer/common": "^1.0.0"
       }
@@ -2357,6 +2383,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.2.0.tgz",
       "integrity": "sha512-d7MwsfAukZJo1GpPrcPGa3MxaFFOqNp0gbqF+3F7pTeNDOgeJN1muXzx1XXDPt+Ac+/voCzsH7qXqnn+xReG/g==",
+      "dev": true,
       "dependencies": {
         "@lezer/common": "^1.0.0",
         "@lezer/highlight": "^1.0.0"
@@ -3419,6 +3446,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -3530,6 +3558,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/array-move/-/array-move-4.0.0.tgz",
       "integrity": "sha512-+RY54S8OuVvg94THpneQvFRmqWdAHeqtMzgMW6JNurHxe8rsS07cHQdfGkXnTUXiBcyZ0j3SiDIxxj0RPiqCkQ==",
+      "dev": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
@@ -3992,20 +4021,21 @@
       }
     },
     "node_modules/bpmn-js-element-templates": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-1.16.0.tgz",
-      "integrity": "sha512-m556VTAgKun4wLGBfX26dAYJ+j+UkMKeyIHILuRtq1c0lCV++0AuUCBSWGL7hv5Aw96oAEkH2zIOLWc9Qg/gyw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/bpmn-js-element-templates/-/bpmn-js-element-templates-2.3.0.tgz",
+      "integrity": "sha512-ZtTPMG5bwPxPGkmrVwWxrPBBCDWRFrJnEMhqBsPEfoE4V5NWeLzlFLhBQzfCOo50Q2VEEJSNv5Okpe/TIy0cvw==",
+      "dev": true,
       "dependencies": {
         "@bpmn-io/element-templates-validator": "^2.1.0",
-        "@bpmn-io/extract-process-variables": "^0.8.0",
-        "bpmnlint": "^10.0.0",
+        "@bpmn-io/extract-process-variables": "^1.0.0",
+        "bpmnlint": "^10.3.0",
         "classnames": "^2.3.1",
         "ids": "^1.0.0",
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.3",
         "preact-markup": "^2.1.1",
         "semver-compare": "^1.0.0",
-        "uuid": "^9.0.1"
+        "uuid": "^10.0.0"
       },
       "engines": {
         "node": "*"
@@ -4018,10 +4048,20 @@
         "diagram-js": ">= 11.9"
       }
     },
+    "node_modules/bpmn-js-element-templates/node_modules/@bpmn-io/extract-process-variables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@bpmn-io/extract-process-variables/-/extract-process-variables-1.0.0.tgz",
+      "integrity": "sha512-4EpxKwsV1h1ttlFywo8Af+JBhGzmmv63C8x2Fu5traH8z/4VJbPa2AncIU2GFHj7LYeZlygEDYWPB0QRYoQWKg==",
+      "dev": true,
+      "dependencies": {
+        "min-dash": "^4.0.0"
+      }
+    },
     "node_modules/bpmn-js-element-templates/node_modules/domify": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
       "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -4030,6 +4070,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
       "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
+      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -4040,6 +4081,7 @@
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.14.0.tgz",
       "integrity": "sha512-Xc0+FxKnbvsxifG8eXPdjqOR8/d10tiGlbyh3wye3J/wrBGQ7BGUM00nexLtQ4fL9eSe3TOPJ0UePk3lrzslPw==",
+      "dev": true,
       "dependencies": {
         "@bpmn-io/extract-process-variables": "^0.8.0",
         "array-move": "^4.0.0",
@@ -4061,6 +4103,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
       "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -4069,6 +4112,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
       "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
+      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -4104,17 +4148,18 @@
       }
     },
     "node_modules/bpmnlint": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-10.2.0.tgz",
-      "integrity": "sha512-lCk8tmrd8Jr0rcYQ1kJa6axkEuMPo+7yilPGjdtTpxD2Zbnf77yLbWX1iTEvI9kt0o/1qww7tZv+Vl0sFWtEhA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/bpmnlint/-/bpmnlint-10.3.1.tgz",
+      "integrity": "sha512-yKkL9iJLBWGTRgiJNiZ4zsJHXwyJmmgQij/4fhRMMfsEDWNk0V5iFtGYF57jH4o/riXTfIototyy/MxOCAyu2g==",
+      "dev": true,
       "dependencies": {
         "@bpmn-io/moddle-utils": "^0.2.1",
         "ansi-colors": "^4.1.3",
-        "bpmn-moddle": "^8.0.1",
+        "bpmn-moddle": "^8.1.0",
         "bpmnlint-utils": "^1.1.1",
         "cli-table": "^0.3.11",
         "color-support": "^1.1.3",
-        "min-dash": "^4.1.1",
+        "min-dash": "^4.2.1",
         "mri": "^1.2.0",
         "pluralize": "^7.0.0",
         "tiny-glob": "^0.2.9"
@@ -4129,7 +4174,8 @@
     "node_modules/bpmnlint-utils": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/bpmnlint-utils/-/bpmnlint-utils-1.1.1.tgz",
-      "integrity": "sha512-Afdb77FmwNB3INyUfbzXW40yY+mc0qYU3SgDFeI4zTtduiVomOlfqoXiEaUIGI8Hyh7aVYpmf3O97P2w7x0DYQ=="
+      "integrity": "sha512-Afdb77FmwNB3INyUfbzXW40yY+mc0qYU3SgDFeI4zTtduiVomOlfqoXiEaUIGI8Hyh7aVYpmf3O97P2w7x0DYQ==",
+      "dev": true
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4421,6 +4467,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/camunda-bpmn-js-behaviors/-/camunda-bpmn-js-behaviors-1.3.0.tgz",
       "integrity": "sha512-Nz+Fa5B6SVUq6d+Mb0UOP0GZI6a+NrMwUXKeyA5LSXjVEKxwso500PGwbzW7HGgFfqT40Fv8i/ukvI0adTBPyA==",
+      "dev": true,
       "dependencies": {
         "ids": "^1.0.0",
         "min-dash": "^4.0.0"
@@ -4435,6 +4482,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/camunda-bpmn-moddle/-/camunda-bpmn-moddle-7.0.1.tgz",
       "integrity": "sha512-Br8Diu6roMpziHdpl66Dhnm0DTnCFMrSD9zwLV08LpD52QA0UsXxU87XfHf08HjuB7ly0Hd1bvajZRpf9hbmYQ==",
+      "dev": true,
       "peer": true
     },
     "node_modules/caniuse-api": {
@@ -4594,7 +4642,8 @@
     "node_modules/classnames": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
-      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "dev": true
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -4621,6 +4670,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
       "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "dev": true,
       "dependencies": {
         "colors": "1.0.3"
       },
@@ -4686,6 +4736,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
       "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
       "bin": {
         "color-support": "bin.js"
       }
@@ -4716,6 +4767,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
+      "dev": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -4894,7 +4946,8 @@
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
+      "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+      "dev": true
     },
     "node_modules/cross-env": {
       "version": "7.0.3",
@@ -6717,6 +6770,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/feelers/-/feelers-1.3.1.tgz",
       "integrity": "sha512-vynmIHhjttmT0wfzbI+Nmi84wLbLwUt83NXo5YTQMReIjRwgHhQpxs7koixX/flJIlTG8M4eukc1U1oQAYkhNw==",
+      "dev": true,
       "dependencies": {
         "@bpmn-io/cm-theme": "^0.1.0-alpha.2",
         "@bpmn-io/feel-lint": "^1.2.0",
@@ -6742,6 +6796,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
       "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -6750,6 +6805,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
       "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
+      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -6760,6 +6816,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/feelin/-/feelin-3.0.1.tgz",
       "integrity": "sha512-aYXH3UYkM2eopg3scgNRNEo/ecwizKH6qTqkEu5nSLMMlMgfhLDhWrLl7ChG5iHspO9o4Q2YSP1o4wW8q0L2Qw==",
+      "dev": true,
       "dependencies": {
         "@lezer/lr": "^1.3.9",
         "lezer-feel": "^1.2.5",
@@ -7029,6 +7086,7 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
       "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
+      "dev": true,
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -7421,12 +7479,14 @@
     "node_modules/globalyzer": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/globalyzer/-/globalyzer-0.1.0.tgz",
-      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q=="
+      "integrity": "sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==",
+      "dev": true
     },
     "node_modules/globrex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg=="
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true
     },
     "node_modules/globule": {
       "version": "1.3.4",
@@ -8697,7 +8757,8 @@
     "node_modules/json-source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/json-source-map/-/json-source-map-0.6.1.tgz",
-      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg=="
+      "integrity": "sha512-1QoztHPsMQqhDq0hlXY5ZqcEdUzxQEIxgFkKl4WUp2pgShObl+9ovi4kRh2TfvAfxAoHOJ9vIMEqk3k4iex7tg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -8927,6 +8988,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lang-feel/-/lang-feel-2.0.0.tgz",
       "integrity": "sha512-cMD6EIhb7vyXLs4kXmaphfZZNr5SkbRxmkfsZUjUJzOV5YxyKBF73VI/8fC3GDUifzs0lVo2DruVszk5igrddg==",
+      "dev": true,
       "dependencies": {
         "@codemirror/autocomplete": "^6.9.1",
         "@codemirror/language": "^6.9.1",
@@ -8956,6 +9018,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/lezer-feel/-/lezer-feel-1.2.8.tgz",
       "integrity": "sha512-CO5JEpwNhH1p8mmRRcqMjJrYxO3vNx0nEsF9Ak4OPa1pNHEqvJ2rwYwM9LjZ7jh/Sl5FxbTJT/teF9a+zWmflg==",
+      "dev": true,
       "dependencies": {
         "@lezer/highlight": "^1.2.0",
         "@lezer/lr": "^1.4.0"
@@ -9233,6 +9296,7 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
       "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "dev": true,
       "engines": {
         "node": ">=12"
       }
@@ -9902,6 +9966,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
       "integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11085,6 +11150,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -11670,6 +11736,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/preact-markup/-/preact-markup-2.1.1.tgz",
       "integrity": "sha512-8JL2p36mzK8XkspOyhBxUSPjYwMxDM0L5BWBZWxsZMVW8WsGQrYQDgVuDKkRspt2hwrle+Cxr/053hpc9BJwfw==",
+      "dev": true,
       "peerDependencies": {
         "preact": ">=10"
       }
@@ -12843,7 +12910,8 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true
     },
     "node_modules/semver/node_modules/lru-cache": {
       "version": "6.0.0",
@@ -13533,7 +13601,8 @@
     "node_modules/style-mod": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
-      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="
+      "integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+      "dev": true
     },
     "node_modules/stylehacks": {
       "version": "5.1.1",
@@ -13608,7 +13677,8 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "dev": true
     },
     "node_modules/tapable": {
       "version": "2.2.1",
@@ -13786,6 +13856,7 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/tiny-glob/-/tiny-glob-0.2.9.tgz",
       "integrity": "sha512-g/55ssRPUjShh+xkfx9UPDXqhckHEsHr4Vd9zX55oSdGZc/MD0m3sferOkwWtp98bv+kcVfEHtRJgBVJzelrzg==",
+      "dev": true,
       "dependencies": {
         "globalyzer": "0.1.0",
         "globrex": "^0.1.2"
@@ -14223,9 +14294,10 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -14265,7 +14337,8 @@
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
-      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true
     },
     "node_modules/watchpack": {
       "version": "2.4.1",
@@ -14696,7 +14769,8 @@
     "node_modules/zeebe-bpmn-moddle": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/zeebe-bpmn-moddle/-/zeebe-bpmn-moddle-1.1.0.tgz",
-      "integrity": "sha512-ES/UZFO0VmKvAzL4+cD3VcQpKvlmgLtnFKTyiv0DdDcxNrdQg1rI0OmUdrKMiybAbtAgPDkVXZCusE3kkXwEyQ=="
+      "integrity": "sha512-ES/UZFO0VmKvAzL4+cD3VcQpKvlmgLtnFKTyiv0DdDcxNrdQg1rI0OmUdrKMiybAbtAgPDkVXZCusE3kkXwEyQ==",
+      "dev": true
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
-        "@bpmn-io/diagram-js-ui": "^0.2.3",
         "@carbon/styles": "^1.53.1",
-        "bpmn-js": "^17.9.1",
-        "diagram-js": "^14.8.0",
         "min-dash": "^4.2.1",
         "min-dom": "^5.0.0"
       },
@@ -28,12 +25,14 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@testing-library/preact": "^3.2.3",
         "babel-loader": "^9.1.3",
+        "bpmn-js": "^17.11.1",
         "bpmn-js-create-append-anything": "^0.5.1",
         "bpmn-js-element-templates": "^2.3.0",
         "bpmn-js-properties-panel": "^5.14.0",
         "camunda-bpmn-js-behaviors": "^1.3.0",
         "cross-env": "^7.0.3",
         "css-loader": "^6.7.1",
+        "diagram-js": "^14.11.1",
         "dotenv": "^16.4.5",
         "dotenv-webpack": "^8.0.1",
         "downloadjs": "^1.4.7",
@@ -1810,6 +1809,7 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bpmn-io/diagram-js-ui/-/diagram-js-ui-0.2.3.tgz",
       "integrity": "sha512-OGyjZKvGK8tHSZ0l7RfeKhilGoOGtFDcoqSGYkX0uhFlo99OVZ9Jn1K7TJGzcE9BdKwvA5Y5kGqHEhdTxHvFfw==",
+      "dev": true,
       "dependencies": {
         "htm": "^3.1.1",
         "preact": "^10.11.2"
@@ -3994,12 +3994,13 @@
       "dev": true
     },
     "node_modules/bpmn-js": {
-      "version": "17.9.1",
-      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-17.9.1.tgz",
-      "integrity": "sha512-yuCGfVwdZpWc+JqqL3Y8oV3HR44TkzsZ7PY/eUINhihKXe1W5ghqLNEYEmEU6JlVlHpELKewvrdEuuMmdIy1Qw==",
+      "version": "17.11.1",
+      "resolved": "https://registry.npmjs.org/bpmn-js/-/bpmn-js-17.11.1.tgz",
+      "integrity": "sha512-ywCeTg5kvN8lYkU+fHE+YXTGlfKc55lRBn7zW3k1//toeMNPy/PS/uQiujRWdFhMrH5dbtDvlwWukNw2pjWw8Q==",
+      "dev": true,
       "dependencies": {
         "bpmn-moddle": "^8.1.0",
-        "diagram-js": "^14.7.2",
+        "diagram-js": "^14.10.0",
         "diagram-js-direct-editing": "^3.0.1",
         "ids": "^1.0.5",
         "inherits-browser": "^0.1.0",
@@ -4123,6 +4124,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
       "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -4131,6 +4133,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
       "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
+      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -4141,6 +4144,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/bpmn-moddle/-/bpmn-moddle-8.1.0.tgz",
       "integrity": "sha512-yI5OAFfYVJwViKTsTsonVfCBPtB3MlefADUORwNIxxBOMp21vnoxuxsdgUWlPH/dvAEZh/+mr8UtqOBNu8NC5Q==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.0.0",
         "moddle": "^6.2.3",
@@ -4693,6 +4697,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
       "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4808,7 +4813,8 @@
     "node_modules/component-event": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -5489,9 +5495,10 @@
       "dev": true
     },
     "node_modules/diagram-js": {
-      "version": "14.8.0",
-      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-14.8.0.tgz",
-      "integrity": "sha512-HV3R6i+hl2PyhsdOQ1pqOsI+JCkX/bYJiHgO5zAaExORtuDrdGVDW7lKsEfcrcGA0fXfpEcmerjOmdH/PIvyJA==",
+      "version": "14.11.1",
+      "resolved": "https://registry.npmjs.org/diagram-js/-/diagram-js-14.11.1.tgz",
+      "integrity": "sha512-J4hIq42Fi5Lx7Q86bNZmdASCVo5IpzylsG5BRzZ6dE1Pk650NTm3JvqR17lQhhL8iH4howcPX5AYU/Zs28ncXQ==",
+      "dev": true,
       "dependencies": {
         "@bpmn-io/diagram-js-ui": "^0.2.3",
         "clsx": "^2.1.0",
@@ -5511,6 +5518,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/diagram-js-direct-editing/-/diagram-js-direct-editing-3.0.1.tgz",
       "integrity": "sha512-V44JO55nwFbsRv6tTmrfdz6fIsE3A4YIIqInaeJZyD2EongZzEo4acH9TqsE4hi9R/kAqsyttMKxTAgHplFn8w==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.0.0",
         "min-dom": "^4.0.2"
@@ -5526,6 +5534,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
       "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -5534,6 +5543,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
       "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
+      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -5554,6 +5564,7 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
       "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -5562,6 +5573,7 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
       "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
+      "dev": true,
       "dependencies": {
         "component-event": "^0.2.1",
         "domify": "^1.4.1",
@@ -5572,6 +5584,7 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/didi/-/didi-10.2.2.tgz",
       "integrity": "sha512-l8NYkYFXV1izHI65EyT8EXOjUZtKmQkHLTT89cSP7HU5J/G7AOj0dXKtLc04EXYlga99PBY18IPjOeZ+c3DI4w==",
+      "dev": true,
       "engines": {
         "node": ">= 16"
       }
@@ -7672,7 +7685,8 @@
     "node_modules/htm": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
-      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ=="
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "dev": true
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -7865,7 +7879,8 @@
     "node_modules/ids": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ids/-/ids-1.0.5.tgz",
-      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw=="
+      "integrity": "sha512-XQ0yom/4KWTL29sLG+tyuycy7UmeaM/79GRtSJq6IG9cJGIPeBz5kwDCguie3TwxaMNIc3WtPi0cTa1XYHicpw==",
+      "dev": true
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -7994,7 +8009,8 @@
     "node_modules/inherits-browser": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/inherits-browser/-/inherits-browser-0.1.0.tgz",
-      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw=="
+      "integrity": "sha512-CJHHvW3jQ6q7lzsXPpapLdMx5hDpSF3FSh45pwsj6bKxJJ8Nl8v43i5yXnr3BdfOimGHKyniewQtnAIp3vyJJw==",
+      "dev": true
     },
     "node_modules/internal-slot": {
       "version": "1.0.7",
@@ -9948,6 +9964,7 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/moddle/-/moddle-6.2.3.tgz",
       "integrity": "sha512-bLVN+ZHL3aKnhxc19XtjUfvdJsS3EsiEJC7bT6YPD11qYmTzvsxrGgyYz1Ouof7TZuGw0lDJ1OLmEnxcpQWk3Q==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.0.0"
       }
@@ -9956,6 +9973,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/moddle-xml/-/moddle-xml-10.1.0.tgz",
       "integrity": "sha512-erWckwLt+dYskewKXJso9u+aAZ5172lOiYxSOqKCPTy7L/xmqH1PoeoA7eVC7oJTt3PqF5TkZzUmbjGH6soQBg==",
+      "dev": true,
       "dependencies": {
         "min-dash": "^4.0.0",
         "moddle": "^6.0.0",
@@ -10679,6 +10697,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/object-refs/-/object-refs-0.4.0.tgz",
       "integrity": "sha512-6kJqKWryKZmtte6QYvouas0/EIJKPI1/MMIuRsiBlNuhIMfqYTggzX2F1AJ2+cDs288xyi9GL7FyasHINR98BQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }
@@ -11045,6 +11064,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/path-intersection/-/path-intersection-3.1.0.tgz",
       "integrity": "sha512-3xS3lvv/vuwm5aH2BVvNRvnvwR2Drde7jQClKpCXTYXIMMjcw/EnMhzCgeHwqbCpzi760PEfAkU53vSIlrNr9A==",
+      "dev": true,
       "engines": {
         "node": ">= 14.20"
       }
@@ -11727,6 +11747,7 @@
       "version": "10.19.7",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.19.7.tgz",
       "integrity": "sha512-IJOW6cQN1fwfC17HfNOqUtAGyB8wAYshuC+jG1JiL/1+sC4yVyuA3IcF0N9vdodMJjW/lbuEF5qFsJqGNcbHbw==",
+      "dev": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -12818,7 +12839,8 @@
     "node_modules/saxen": {
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/saxen/-/saxen-8.1.2.tgz",
-      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw=="
+      "integrity": "sha512-xUOiiFbc3Ow7p8KMxwsGICPx46ZQvy3+qfNVhrkwfz3Vvq45eGt98Ft5IQaA1R/7Tb5B5MKh9fUR9x3c3nDTxw==",
+      "dev": true
     },
     "node_modules/schema-utils": {
       "version": "4.2.0",
@@ -13865,7 +13887,8 @@
     "node_modules/tiny-svg": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/tiny-svg/-/tiny-svg-3.1.2.tgz",
-      "integrity": "sha512-qvNlv/4N48HqbNpwAhzQ9HKHlBUKgA4091x+aVfsrRXHIcQ9NA3W6ZYwdmYAIdwT+vfAAksrc9L/3RQBj5KwPw=="
+      "integrity": "sha512-qvNlv/4N48HqbNpwAhzQ9HKHlBUKgA4091x+aVfsrRXHIcQ9NA3W6ZYwdmYAIdwT+vfAAksrc9L/3RQBj5KwPw==",
+      "dev": true
     },
     "node_modules/tmp": {
       "version": "0.2.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@carbon/styles": "^1.53.1",
         "min-dash": "^4.2.1",
-        "min-dom": "^5.0.0"
+        "min-dom": "^4.2.1"
       },
       "devDependencies": {
         "@babel/core": "^7.18.10",
@@ -1881,26 +1881,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/@bpmn-io/feel-editor/node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@bpmn-io/feel-editor/node_modules/min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
-      }
-    },
     "node_modules/@bpmn-io/feel-lint": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@bpmn-io/feel-lint/-/feel-lint-1.2.0.tgz",
@@ -1939,26 +1919,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/@bpmn-io/properties-panel/node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@bpmn-io/properties-panel/node_modules/min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
       }
     },
     "node_modules/@camunda/element-templates-json-schema": {
@@ -4058,26 +4018,6 @@
         "min-dash": "^4.0.0"
       }
     },
-    "node_modules/bpmn-js-element-templates/node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bpmn-js-element-templates/node_modules/min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
-      }
-    },
     "node_modules/bpmn-js-properties-panel": {
       "version": "5.14.0",
       "resolved": "https://registry.npmjs.org/bpmn-js-properties-panel/-/bpmn-js-properties-panel-5.14.0.tgz",
@@ -4098,46 +4038,6 @@
         "bpmn-js": ">= 11.5",
         "camunda-bpmn-js-behaviors": ">= 0.4",
         "diagram-js": ">= 11.9"
-      }
-    },
-    "node_modules/bpmn-js-properties-panel/node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bpmn-js-properties-panel/node_modules/min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
-      }
-    },
-    "node_modules/bpmn-js/node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/bpmn-js/node_modules/min-dom": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
-      "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
-      "dev": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.2.1"
       }
     },
     "node_modules/bpmn-moddle": {
@@ -4813,8 +4713,7 @@
     "node_modules/component-event": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/component-event/-/component-event-0.2.1.tgz",
-      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw==",
-      "dev": true
+      "integrity": "sha512-wGA++isMqiDq1jPYeyv2as/Bt/u+3iLW0rEa+8NQ82jAv3TgqMiCM+B2SaBdn2DfLilLjjq736YcezihRYhfxw=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -5530,26 +5429,6 @@
         "diagram-js": "*"
       }
     },
-    "node_modules/diagram-js-direct-editing/node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/diagram-js-direct-editing/node_modules/min-dom": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
-      "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
-      "dev": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.2.1"
-      }
-    },
     "node_modules/diagram-js-grid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/diagram-js-grid/-/diagram-js-grid-1.0.0.tgz",
@@ -5558,26 +5437,6 @@
       "dependencies": {
         "min-dash": "^4.1.1",
         "tiny-svg": "^3.0.1"
-      }
-    },
-    "node_modules/diagram-js/node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/diagram-js/node_modules/min-dom": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
-      "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
-      "dev": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.2.1"
       }
     },
     "node_modules/didi": {
@@ -5689,12 +5548,9 @@
       }
     },
     "node_modules/domify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-2.0.0.tgz",
-      "integrity": "sha512-rmvrrmWQPD/X1A/nPBfIVg4r05792QdG9Z4Prk6oQG0F9zBMDkr0GKAdds1wjb2dq1rTz/ywc4ZxpZbgz0tttg==",
-      "engines": {
-        "node": ">=18"
-      },
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
+      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
@@ -6805,26 +6661,6 @@
         "node": "*"
       }
     },
-    "node_modules/feelers/node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/feelers/node_modules/min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
-      }
-    },
     "node_modules/feelin": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/feelin/-/feelin-3.0.1.tgz",
@@ -6846,26 +6682,6 @@
       "dev": true,
       "dependencies": {
         "min-dom": "^4.0.3"
-      }
-    },
-    "node_modules/file-drops/node_modules/domify": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/domify/-/domify-1.4.2.tgz",
-      "integrity": "sha512-m4yreHcUWHBncGVV7U+yQzc12vIlq0jMrtHZ5mW6dQMiL/7skSYNVX9wqKwOtyO9SGCgevrAFEgOCAHmamHTUA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/file-drops/node_modules/min-dom": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.1.0.tgz",
-      "integrity": "sha512-1lj1EyoSwY/UmTeT/hhPiZTsq+vK9D+8FAJ/53iK5jT1otkG9rJTixSKdjmTieEvdfES+sKbbTptzaQJhnacjA==",
-      "dev": true,
-      "dependencies": {
-        "component-event": "^0.2.1",
-        "domify": "^1.4.1",
-        "min-dash": "^4.0.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -9611,11 +9427,12 @@
       "integrity": "sha512-to+unsToePnm7cUeR9TrMzFlETHd/UXmU+ELTRfWZj5XGT41KF6X3L233o3E/GdEs3sk2Tbw/lOLD1avmWkg8A=="
     },
     "node_modules/min-dom": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-5.0.0.tgz",
-      "integrity": "sha512-eqZlSlxmCje0Q1B4sR2RUuh5DOE8FyYLPo35xuJabHBrlzEcG/DFg09TT2tIWRVB3w/6ZgCBkVIPpcOiD66BxQ==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/min-dom/-/min-dom-4.2.1.tgz",
+      "integrity": "sha512-TMoL8SEEIhUWYgkj7XMSgxmwSyGI+4fP2KFFGnN3FbHfbGHVdsLYSz8LoIsgPhz4dWRmLvxWWSMgzZMJW5sZuA==",
       "dependencies": {
-        "domify": "^2.0.0",
+        "component-event": "^0.2.1",
+        "domify": "^1.4.1",
         "min-dash": "^4.2.1"
       }
     },

--- a/package.json
+++ b/package.json
@@ -42,10 +42,7 @@
     "prepare": "run-s build"
   },
   "dependencies": {
-    "@bpmn-io/diagram-js-ui": "^0.2.3",
     "@carbon/styles": "^1.53.1",
-    "bpmn-js": "^17.9.1",
-    "diagram-js": "^14.8.0",
     "min-dash": "^4.2.1",
     "min-dom": "^5.0.0"
   },
@@ -61,12 +58,14 @@
     "@rollup/plugin-node-resolve": "^15.2.3",
     "@testing-library/preact": "^3.2.3",
     "babel-loader": "^9.1.3",
+    "bpmn-js": "^17.11.1",
     "bpmn-js-create-append-anything": "^0.5.1",
     "bpmn-js-element-templates": "^2.3.0",
     "bpmn-js-properties-panel": "^5.14.0",
     "camunda-bpmn-js-behaviors": "^1.3.0",
     "cross-env": "^7.0.3",
     "css-loader": "^6.7.1",
+    "diagram-js": "^14.11.1",
     "dotenv": "^16.4.5",
     "dotenv-webpack": "^8.0.1",
     "downloadjs": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@bpmn-io/diagram-js-ui": "^0.2.3",
     "@carbon/styles": "^1.53.1",
     "bpmn-js": "^17.9.1",
-    "bpmn-js-element-templates": "^1.16.0",
     "diagram-js": "^14.8.0",
     "min-dash": "^4.2.1",
     "min-dom": "^5.0.0"
@@ -63,6 +62,7 @@
     "@testing-library/preact": "^3.2.3",
     "babel-loader": "^9.1.3",
     "bpmn-js-create-append-anything": "^0.5.1",
+    "bpmn-js-element-templates": "^2.3.0",
     "bpmn-js-properties-panel": "^5.14.0",
     "camunda-bpmn-js-behaviors": "^1.3.0",
     "cross-env": "^7.0.3",
@@ -101,5 +101,9 @@
     "style-loader": "^3.3.1",
     "webpack": "^5.88.2",
     "zeebe-bpmn-moddle": "^1.0.0"
+  },
+  "peerDependencies": {
+    "bpmn-js": "*",
+    "diagram-js": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@carbon/styles": "^1.53.1",
     "min-dash": "^4.2.1",
-    "min-dom": "^5.0.0"
+    "min-dom": "^4.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.18.10",
@@ -103,6 +103,7 @@
   },
   "peerDependencies": {
     "bpmn-js": "*",
+    "bpmn-js-element-templates": "*",
     "diagram-js": "*"
   }
 }


### PR DESCRIPTION
### Proposed Changes

I've observed that this module is the reason for [decaying downstream dependency trees](https://github.com/camunda/web-modeler/pull/10940). As an alternative to regular dependency updates (extra maintainance) we can mark dependencies to utilities as peers. This is what I propose to do.

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [ ] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
