### PR TITLE
fix: do not pre-fetch refactorings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,7 +4,7 @@ jobs:
   Build:
     strategy:
       matrix:
-        os: [ubuntu-latest ]
+        os: [ubuntu-latest]
         node-version: [20]
 
     runs-on: ${{ matrix.os }}
@@ -19,6 +19,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
+      - name: Setup project
+        uses: bpmn-io/actions/setup@latest
       - name: Create .env file
         run: |
           touch .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to [@bpmn-io/refactorings](https://github.com/bpmn-io/refact
 
 ___Note:__ Yet to be released changes appear here._
 
+## 1.0.1
+
+* `FIX`: do not pre-fetch refactorings ([#31](https://github.com/bpmn-io/refactorings/pull/31))
+
 ## 1.0.0
 
 * `DEPS`: cleanup dependencies

--- a/lib/context-pad/RefactoringsContextPadProvider.js
+++ b/lib/context-pad/RefactoringsContextPadProvider.js
@@ -35,9 +35,6 @@ export default class RefactoringsContextPadProvider {
         return entries;
       }
 
-      // pre-fetch results
-      this._refactorings.getRefactorings([ element ]);
-
       const {
         delete: deleteEntry,
         ...rest

--- a/test/spec/context-pad/RefactoringsContextPadProvider.spec.js
+++ b/test/spec/context-pad/RefactoringsContextPadProvider.spec.js
@@ -64,21 +64,6 @@ describe('Context Pad', function() {
   }));
 
 
-  it('should pre-fetch results in popup menu provider', inject(function(elementRegistry, contextPad, refactorings) {
-
-    // given
-    const task = elementRegistry.get('Task_1');
-
-    refactorings.getRefactorings = sinon.spy();
-
-    // when
-    contextPad.open(task);
-
-    // then
-    expect(refactorings.getRefactorings).to.have.been.calledWith([ task ]);
-  }));
-
-
   it('should open popup menu on click', inject(async function(elementRegistry, contextPad, popupMenu) {
 
     // given


### PR DESCRIPTION
Closes #30

### Proposed Changes

Disables pre-fetching of refactorings when opening the context pad. As a result there is a slight delay when opening the popup:

![brave_Mxq2mIZsPP](https://github.com/user-attachments/assets/95866937-c983-4936-ab6e-49beb1bbf428)


<!--

Add relevant context (issue fixed or related to), 
a capture of the UI changes (if any) as well as 
steps to try out your changes.

--> 

### Checklist

To ensure you provided everything we need to look at your PR:

* [x] **Brief textual description** of the changes present
* [x] **Visual demo** attached
* [ ] **Steps to try out** present, i.e. [using the `@bpmn-io/sr` tool](https://github.com/bpmn-io/sr)
* [x] Related issue linked via `Closes {LINK_TO_ISSUE}` or `Related to {LINK_TO_ISSUE}`

<!--

Thanks for creating this pull request! ❤️

-->
